### PR TITLE
Simplified render-pdf and added distclean as well as amended clone-info/name targets

### DIFF
--- a/mqtt-sn-2.0/prose/edit/makefile
+++ b/mqtt-sn-2.0/prose/edit/makefile
@@ -150,7 +150,7 @@ clone-info:
 	printf "%s name.is(): '%s'\n" "-" "$$(basename `git rev-parse --show-toplevel`)"
 	printf "%s branch.is(): '%s'\n" "-" "$$(git branch --show-current)"
 	printf "%s revision.is(): sha1:%s\n" "-" "$$(git rev-parse HEAD)"
-	printf "%s location.is(): '%s'\n" "-" "$$(python -c "$$(printf "from pathlib import Path; g = '.git'; o = p = c = Path().resolve(); x = lambda p, c, g: (c, c.parent if not (c / g).is_dir() else c); _ , c = x(p, c, g);|while c != p and str(c) != '/': p, c = x(p, c, g);|print(f'(orga/repo={c.parent.name}/{c.name}, rel-path={o.relative_to(c)})' if c == p else '(orga/repo=?, rel-path=?)')" | tr '|' '\n')")"
+	printf "%s location.is(): %s\n" "-" "$$(python -c "$$(printf "from pathlib import Path; g = '.git'; o = p = c = Path().resolve(); x = lambda p, c, g: (c, c.parent if not (c / g).is_dir() else c); _ , c = x(p, c, g);|while c != p and str(c) != '/': p, c = x(p, c, g);|print(f'(orga/repo=\\\'{c.parent.name}/{c.name}\\\', rel-path=\\\'{o.relative_to(c)}\\\')' if c == p else '(orga/repo=\\\'?/?\\\', rel-path=\\\'?\\\')')" | tr '|' '\n')")"
 	printf "%s node.id(): '%s'\n" "-" "$$(python -c 'import platform; import uuid; print(str(uuid.uuid3(uuid.NAMESPACE_DNS, platform.node())))')"
 
 .PHONY: name

--- a/mqtt-sn-2.0/prose/edit/makefile
+++ b/mqtt-sn-2.0/prose/edit/makefile
@@ -150,7 +150,7 @@ clone-info:
 	printf "%s name.is(): '%s'\n" "-" "$$(basename `git rev-parse --show-toplevel`)"
 	printf "%s branch.is(): '%s'\n" "-" "$$(git branch --show-current)"
 	printf "%s revision.is(): sha1:%s\n" "-" "$$(git rev-parse HEAD)"
-	printf "%s location.is(): %s\n" "-" "$$(python -c "$$(printf "from pathlib import Path; g = '.git'; o = p = c = Path().resolve(); x = lambda p, c, g: (c, c.parent if not (c / g).is_dir() else c); _ , c = x(p, c, g);|while c != p and str(c) != '/': p, c = x(p, c, g);|print(f'(orga/repo=\\\'{c.parent.name}/{c.name}\\\', rel-path=\\\'{o.relative_to(c)}\\\')' if c == p else '(orga/repo=\\\'?/?\\\', rel-path=\\\'?\\\')')" | tr '|' '\n')")"
+	printf "%s location.is(): %s\n" "-" "$$(python -c "(lambda _Y: (lambda _mod: (lambda Path: (lambda g: [(lambda x: [(lambda c, p: (lambda _loop1: _loop1(c, p))(_Y(lambda _loop1: (lambda c, p: ([_loop1(c, p) for (p, c) in [x(p, c, g)]][0]) if (c != p) and (str(c) != '/') else print((f\"(orga/repo='{c.parent.name}/{c.name}', rel-path='{o.relative_to(c)}')\" if (c == p) else \"(orga/repo='?/?', rel-path='?')\"))))))(c if 'c' in dir() else None, p if 'p' in dir() else None) for (_, c) in [x(p, c, g)]][0])(lambda p, c, g: (c, c.parent if not (c / g).is_dir() else c)) for o, p, c in [[Path().resolve()] * 3]][0])('.git'))(_mod.Path))(__import__('pathlib', {}, {}, ['Path'])))((lambda f: (lambda x: x(x))(lambda y: f(lambda *args: y(y)(*args)))))")"
 	printf "%s node.id(): '%s'\n" "-" "$$(python -c 'import platform; import uuid; print(str(uuid.uuid3(uuid.NAMESPACE_DNS, platform.node())))')"
 
 .PHONY: name

--- a/mqtt-sn-2.0/prose/edit/makefile
+++ b/mqtt-sn-2.0/prose/edit/makefile
@@ -93,12 +93,10 @@ render-pdf:
 	command -v etiketti >/dev/null 2>&1 || { echo >&2 "make render-pdf requires etiketti but it's not installed - you can install per pip install etiketti.  Aborting."; exit 1; }
 	command -v qpdf >/dev/null 2>&1 || { echo >&2 "make render-pdf requires qpdf but it's not installed - you can search the internets on how to install qpdf.  Aborting."; exit 1; }
 	bin/assemble.py -t $(target_pdf) && \
-		mkdir -p $(build_pdf) && \
+		mkdir -p $(build_root)images/ $(build_pdf)images/ && \
 		printf "pdf.md\n" > $(build_root)bind.txt && \
-		mkdir -p $(build_root)/images/ && \
 		cp -a ../media/OASISLogo-v3.0.png $(build_root)images/ && \
 		cp -a src/images/*.{png,jpg} $(build_root)images/ && \
-		mkdir -p $(build_pdf)images/ && \
 		cp -a ../media/OASISLogo-v3.0.png $(build_pdf)images/ && \
 		cp -a $(liitos_templates)approvals.yml $(build_root) && \
 		cp -a $(liitos_templates)bookmatter.tex.in $(build_root) && \
@@ -142,8 +140,18 @@ clean:
 	rm -fr $(build_root)
 	mkdir -p $(build_root)
 
+.PHONY: distclean
+distclean: clean
+	rm -fr $(build_root)
+
 .PHONY: clone-info
 clone-info:
-	printf "Revision-info:\n"
+	printf "Clone-info:\n"
+	printf "%s name.is(): '%s'\n" "-" "$$(basename `git rev-parse --show-toplevel`)"
+	printf "%s branch.is(): '%s'\n" "-" "$$(git branch --show-current)"
 	printf "%s revision.is(): sha1:%s\n" "-" "$$(git rev-parse HEAD)"
+	printf "%s location.is(): '%s'\n" "-" "$$(python -c "$$(printf "from pathlib import Path; g = '.git'; o = p = c = Path().resolve(); x = lambda p, c, g: (c, c.parent if not (c / g).is_dir() else c); _ , c = x(p, c, g);|while c != p and str(c) != '/': p, c = x(p, c, g);|print(f'(orga/repo={c.parent.name}/{c.name}, rel-path={o.relative_to(c)})' if c == p else '(orga/repo=?, rel-path=?)')" | tr '|' '\n')")"
 	printf "%s node.id(): '%s'\n" "-" "$$(python -c 'import platform; import uuid; print(str(uuid.uuid3(uuid.NAMESPACE_DNS, platform.node())))')"
+
+.PHONY: name
+name: clone-info


### PR DESCRIPTION
Maintenance only changes.

The `clone-info` target (with alias `name`) is now more informative for editors:

```bash
❯ make clone-info 
Clone-info:
- name.is(): 'mqtt'
- branch.is(): 'makefile-enhancements'
- revision.is(): sha1:c6d96572914f7b23f7a72d8748255c5193e815ef
- location.is(): (orga/repo='oasis-tcs/mqtt', rel-path='mqtt-sn-2.0/prose/edit')
- node.id(): 'c79891e5-aabf-3a83-95b9-588edcd8327f'
```

Note: The usefulness of the location info relies in part on the placement on the local disk.
If it had been at `/some/funny/path` in above example, the output for `orga/repo` would have been `funny/path`.